### PR TITLE
Add example galaxy.yaml file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,5 @@
+name: "ansible-network.sandbox"
+version: "0.0.20"
+description: "Example sanbox role for testing things"
+authors: ["Ansible Network Contributors"]
+license: "GPL-3.0-or-later"


### PR DESCRIPTION
This will be used by mazer, the new hotness for publish roles into
galaxy. Once in place, we'll actually be able to build tarballs of our
roles then upload them out of band to galaxy.ansible.com.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>