### PR TITLE
Convert to ansible collection for testing

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,4 @@
+- project:
+    post:
+      jobs:
+        - release-ansible-galaxy-collection

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,8 @@
+---
+authors:
+  - Ansible Network Community (ansible-network)
+license_file: LICENSE
+name: sandbox
+namespace: network
+readme: README.rst
+repository: https://github.com/ansible-network/sandbox


### PR DESCRIPTION
Now that collections are the new hotness, convert sandbox to a
collection so we can test publishing content to galaxy.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>